### PR TITLE
Compilation errors fix/workarounds

### DIFF
--- a/dom/base/DirectionalityUtils.cpp
+++ b/dom/base/DirectionalityUtils.cpp
@@ -387,7 +387,7 @@ GetDirectionFromText(const nsTextFragment* aFrag,
  *            know not to return it
  * @return the text node containing the character that determined the direction
  */
-static nsINode*
+static nsTextNode*
 WalkDescendantsSetDirectionFromText(Element* aElement, bool aNotify = true,
                                     nsINode* aChangedNode = nullptr)
 {
@@ -413,7 +413,7 @@ WalkDescendantsSetDirectionFromText(Element* aElement, bool aNotify = true,
         // We found a descendant text node with strong directional characters.
         // Set the directionality of aElement to the corresponding value.
         aElement->SetDirectionality(textNodeDir, aNotify);
-        return child;
+        return static_cast<nsTextNode*>(child);
       }
     }
     child = child->GetNextNode(aElement);
@@ -471,7 +471,7 @@ public:
     NS_RELEASE(textNode);
   }
 
-  void AddEntry(nsINode* aTextNode, Element* aElement)
+  void AddEntry(nsTextNode* aTextNode, Element* aElement)
   {
     if (!mElements.Contains(aElement)) {
       mElements.Put(aElement);
@@ -482,7 +482,7 @@ public:
     }
   }
 
-  void RemoveEntry(nsINode* aTextNode, Element* aElement)
+  void RemoveEntry(nsTextNode* aTextNode, Element* aElement)
   {
     NS_ASSERTION(mElements.Contains(aElement),
                  "element already removed from map");
@@ -542,7 +542,7 @@ private:
       static_cast<nsTextNodeDirectionalityMapAndElement*>(aData);
     nsINode* oldTextNode = data->mNode;
     Element* rootNode = aEntry->GetKey();
-    nsINode* newTextNode = nullptr;
+    nsTextNode* newTextNode = nullptr;
     if (rootNode->GetParentNode() && rootNode->HasDirAuto()) {
       newTextNode = WalkDescendantsSetDirectionFromText(rootNode, true,
                                                         oldTextNode);
@@ -600,14 +600,14 @@ public:
     }
   }
 
-  static void RemoveElementFromMap(nsINode* aTextNode, Element* aElement)
+  static void RemoveElementFromMap(nsTextNode* aTextNode, Element* aElement)
   {
     if (aTextNode->HasTextNodeDirectionalityMap()) {
       GetDirectionalityMap(aTextNode)->RemoveEntry(aTextNode, aElement);
     }
   }
 
-  static void AddEntryToMap(nsINode* aTextNode, Element* aElement)
+  static void AddEntryToMap(nsTextNode* aTextNode, Element* aElement)
   {
     nsTextNodeDirectionalityMap* map = GetDirectionalityMap(aTextNode);
     if (!map) {
@@ -625,8 +625,8 @@ public:
     return GetDirectionalityMap(aTextNode)->UpdateAutoDirection(aDir);
   }
 
-  static void ResetTextNodeDirection(nsINode* aTextNode,
-                                     nsINode* aChangedTextNode)
+  static void ResetTextNodeDirection(nsTextNode* aTextNode,
+                                     nsTextNode* aChangedTextNode)
   {
     MOZ_ASSERT(aTextNode->HasTextNodeDirectionalityMap(),
                "Map missing in ResetTextNodeDirection");
@@ -701,7 +701,7 @@ SetDirectionalityOnDescendants(Element* aElement, Directionality aDir,
 void
 WalkAncestorsResetAutoDirection(Element* aElement, bool aNotify)
 {
-  nsINode* setByNode;
+  nsTextNode* setByNode;
   Element* parent = aElement->GetParentElement();
 
   while (parent && parent->NodeOrAncestorHasDirAuto()) {
@@ -711,7 +711,7 @@ WalkAncestorsResetAutoDirection(Element* aElement, bool aNotify)
       // Remove it from the map and reset its direction by the downward
       // propagation algorithm
       setByNode =
-        static_cast<nsINode*>(parent->GetProperty(nsGkAtoms::dirAutoSetBy));
+        static_cast<nsTextNode*>(parent->GetProperty(nsGkAtoms::dirAutoSetBy));
       if (setByNode) {
         nsTextNodeDirectionalityMap::RemoveElementFromMap(setByNode, parent);
       }
@@ -737,11 +737,9 @@ WalkDescendantsResetAutoDirection(Element* aElement)
       continue;
     }
 
-    if (child->HasTextNodeDirectionalityMap()) {
-      nsTextNodeDirectionalityMap::ResetTextNodeDirection(child, nullptr);
-      // Don't call nsTextNodeDirectionalityMap::EnsureMapIsClearFor(child)
-      // since ResetTextNodeDirection may have kept elements in child's
-      // DirectionalityMap.
+    if (child->NodeType() == nsIDOMNode::TEXT_NODE &&
+        child->HasTextNodeDirectionalityMap()) {
+      nsTextNodeDirectionalityMap::ResetTextNodeDirection(static_cast<nsTextNode*>(child), nullptr);
     }
     child = child->GetNextNode(aElement);
   }
@@ -783,7 +781,7 @@ WalkDescendantsSetDirAuto(Element* aElement, bool aNotify)
     }
   }
 
-  nsINode* textNode = WalkDescendantsSetDirectionFromText(aElement, aNotify);
+  nsTextNode* textNode = WalkDescendantsSetDirectionFromText(aElement, aNotify);
   if (textNode) {
     nsTextNodeDirectionalityMap::AddEntryToMap(textNode, aElement);
   }
@@ -804,7 +802,7 @@ WalkDescendantsClearAncestorDirAuto(Element* aElement)
   }
 }
 
-void SetAncestorDirectionIfAuto(nsINode* aTextNode, Directionality aDir,
+void SetAncestorDirectionIfAuto(nsTextNode* aTextNode, Directionality aDir,
                                 bool aNotify = true)
 {
   MOZ_ASSERT(aTextNode->NodeType() == nsIDOMNode::TEXT_NODE,
@@ -818,8 +816,8 @@ void SetAncestorDirectionIfAuto(nsINode* aTextNode, Directionality aDir,
 
     if (parent->HasDirAuto()) {
       bool resetDirection = false;
-      nsINode* directionWasSetByTextNode =
-        static_cast<nsINode*>(parent->GetProperty(nsGkAtoms::dirAutoSetBy));
+      nsTextNode* directionWasSetByTextNode =
+        static_cast<nsTextNode*>(parent->GetProperty(nsGkAtoms::dirAutoSetBy));
 
       if (!parent->HasDirAutoSet()) {
         // Fast path if parent's direction is not yet set by any descendant
@@ -890,7 +888,7 @@ TextNodeWillChangeDirection(nsIContent* aTextNode, Directionality* aOldDir,
 }
 
 void
-TextNodeChangedDirection(nsIContent* aTextNode, Directionality aOldDir,
+TextNodeChangedDirection(nsTextNode* aTextNode, Directionality aOldDir,
                          bool aNotify)
 {
   Directionality newDir = GetDirectionFromText(aTextNode->GetText());
@@ -920,7 +918,7 @@ TextNodeChangedDirection(nsIContent* aTextNode, Directionality aOldDir,
 }
 
 void
-SetDirectionFromNewTextNode(nsIContent* aTextNode)
+SetDirectionFromNewTextNode(nsTextNode* aTextNode)
 {
   if (!NodeAffectsDirAutoAncestor(aTextNode)) {
     return;
@@ -1007,8 +1005,8 @@ OnSetDirAttr(Element* aElement, const nsAttrValue* aNewValue,
     WalkDescendantsSetDirAuto(aElement, aNotify);
   } else {
     if (aElement->HasDirAutoSet()) {
-      nsINode* setByNode =
-        static_cast<nsINode*>(aElement->GetProperty(nsGkAtoms::dirAutoSetBy));
+      nsTextNode* setByNode =
+        static_cast<nsTextNode*>(aElement->GetProperty(nsGkAtoms::dirAutoSetBy));
       nsTextNodeDirectionalityMap::RemoveElementFromMap(setByNode, aElement);
     }
     SetDirectionalityOnDescendants(aElement,

--- a/dom/base/DirectionalityUtils.h
+++ b/dom/base/DirectionalityUtils.h
@@ -89,14 +89,14 @@ bool TextNodeWillChangeDirection(nsIContent* aTextNode, Directionality* aOldDir,
  * After the contents of a text node have changed, change the directionality
  * of any elements whose directionality is determined by that node
  */
-void TextNodeChangedDirection(nsIContent* aTextNode, Directionality aOldDir,
+void TextNodeChangedDirection(nsTextNode* aTextNode, Directionality aOldDir,
                               bool aNotify);
 
 /**
  * When a text node is appended to an element, find any ancestors with dir=auto
  * whose directionality will be determined by the text node
  */
-void SetDirectionFromNewTextNode(nsIContent* aTextNode);
+void SetDirectionFromNewTextNode(nsTextNode* aTextNode);
 
 /**
  * When a text node is removed from a document, find any ancestors whose

--- a/dom/base/nsGenericDOMDataNode.cpp
+++ b/dom/base/nsGenericDOMDataNode.cpp
@@ -371,7 +371,10 @@ nsGenericDOMDataNode::SetTextInternal(uint32_t aOffset, uint32_t aCount,
   }
 
   if (dirAffectsAncestor) {
-    TextNodeChangedDirection(this, oldDir, aNotify);
+    // dirAffectsAncestor being true implies that we have a text node, see
+    // above.
+    MOZ_ASSERT(NodeType() == nsIDOMNode::TEXT_NODE);
+    TextNodeChangedDirection(static_cast<nsTextNode*>(this), oldDir, aNotify);
   }
 
   // Notify observers

--- a/dom/base/nsINode.h
+++ b/dom/base/nsINode.h
@@ -1621,8 +1621,11 @@ public:
                "ClearHasTextNodeDirectionalityMap on non-text node");
     ClearBoolFlag(NodeHasTextNodeDirectionalityMap);
   }
-  bool HasTextNodeDirectionalityMap() const
-    { return GetBoolFlag(NodeHasTextNodeDirectionalityMap); }
+  bool HasTextNodeDirectionalityMap() const {
+    MOZ_ASSERT(NodeType() == nsIDOMNode::TEXT_NODE,
+               "HasTextNodeDirectionalityMap on non-text node");
+    return GetBoolFlag(NodeHasTextNodeDirectionalityMap);
+  }
 
   void SetHasDirAuto() { SetBoolFlag(NodeHasDirAuto); }
   void ClearHasDirAuto() { ClearBoolFlag(NodeHasDirAuto); }

--- a/dom/base/nsTextNode.h
+++ b/dom/base/nsTextNode.h
@@ -49,6 +49,7 @@ public:
 
   // nsIDOMNode
   NS_FORWARD_NSIDOMNODE_TO_NSINODE
+  using mozilla::dom::Text::GetParentElement;
 
   // nsIDOMCharacterData
   NS_FORWARD_NSIDOMCHARACTERDATA(nsGenericDOMDataNode::)

--- a/media/libopus/silk/NSQ_del_dec.c
+++ b/media/libopus/silk/NSQ_del_dec.c
@@ -106,6 +106,13 @@ static OPUS_INLINE void silk_noise_shape_quantizer_del_dec(
     opus_int            decisionDelay           /* I                                        */
 );
 
+#if (__GNUC__ == 4 && __GNUC_MINOR__ == 8 && __GNUC_PATCHLEVEL__ == 5)
+#ifdef TENFOURFOX_G5
+/* work around issue 461 */
+__attribute__((optimize("no-tree-vectorize")))
+#endif
+#endif
+
 void silk_NSQ_del_dec(
     const silk_encoder_state    *psEncC,                                    /* I/O  Encoder State                   */
     silk_nsq_state              *NSQ,                                       /* I/O  NSQ state                       */

--- a/media/libyuv/source/row_common.cc
+++ b/media/libyuv/source/row_common.cc
@@ -1116,6 +1116,13 @@ void I422ToARGB4444Row_C(const uint8* src_y,
   }
 }
 
+#if (__GNUC__ == 4 && __GNUC_MINOR__ == 8 && __GNUC_PATCHLEVEL__ == 5)
+#ifdef __ppc__
+/* work around issue 461 */
+__attribute__((optimize("no-tree-vectorize")))
+#endif
+#endif
+
 void I422ToARGB1555Row_C(const uint8* src_y,
                          const uint8* src_u,
                          const uint8* src_v,
@@ -1153,6 +1160,16 @@ void I422ToARGB1555Row_C(const uint8* src_y,
         0x8000;
   }
 }
+
+#if (__GNUC__ == 4 && __GNUC_MINOR__ == 8 && __GNUC_PATCHLEVEL__ == 5)
+#ifdef __ppc__
+#ifndef TENFOURFOX_G5
+/* Work around issue 461, 7450 only
+   Safe to comment for a 7400 build */
+__attribute__((optimize("no-tree-vectorize")))
+#endif
+#endif
+#endif
 
 void I422ToRGB565Row_C(const uint8* src_y,
                        const uint8* src_u,
@@ -1280,6 +1297,14 @@ void NV21ToARGBRow_C(const uint8* src_y,
   }
 }
 
+#if (__GNUC__ == 4 && __GNUC_MINOR__ == 8 && __GNUC_PATCHLEVEL__ == 5)
+#ifdef __ppc__
+/* work around issue 461 */
+__attribute__((optimize("no-tree-vectorize")))
+#endif
+#endif
+
+
 void NV12ToRGB565Row_C(const uint8* src_y,
                        const uint8* usrc_v,
                        uint8* dst_rgb565,
@@ -1314,6 +1339,13 @@ void NV12ToRGB565Row_C(const uint8* src_y,
     *(uint16*)(dst_rgb565) = b0 | (g0 << 5) | (r0 << 11);
   }
 }
+
+#if (__GNUC__ == 4 && __GNUC_MINOR__ == 8 && __GNUC_PATCHLEVEL__ == 5)
+#ifdef __ppc__
+/* work around issue 461 */
+__attribute__((optimize("no-tree-vectorize")))
+#endif
+#endif
 
 void NV21ToRGB565Row_C(const uint8* src_y,
                        const uint8* vsrc_u,

--- a/media/libyuv/source/scale_common.cc
+++ b/media/libyuv/source/scale_common.cc
@@ -88,6 +88,13 @@ void ScaleRowDown4_C(const uint8* src_ptr, ptrdiff_t src_stride,
   }
 }
 
+#if (__GNUC__ == 4 && __GNUC_MINOR__ == 8 && __GNUC_PATCHLEVEL__ == 5)
+#ifdef TENFOURFOX_G5
+/* work around issue 461 */
+__attribute__((optimize("no-tree-vectorize")))
+#endif
+#endif
+
 void ScaleRowDown4Box_C(const uint8* src_ptr, ptrdiff_t src_stride,
                         uint8* dst, int dst_width) {
   intptr_t stride = src_stride;

--- a/media/webrtc/trunk/webrtc/modules/audio_coding/codecs/isac/main/source/entropy_coding.c
+++ b/media/webrtc/trunk/webrtc/modules/audio_coding/codecs/isac/main/source/entropy_coding.c
@@ -385,6 +385,12 @@ int WebRtcIsac_DecodeSpec(Bitstr* streamdata, int16_t AvgPitchGain_Q12,
   return len;
 }
 
+#if (__GNUC__ == 4 && __GNUC_MINOR__ == 8 && __GNUC_PATCHLEVEL__ == 5)
+#ifdef TENFOURFOX_G5
+/* work around issue 461 */
+__attribute__((optimize("no-tree-vectorize")))
+#endif
+#endif
 
 int WebRtcIsac_EncodeSpec(const int16_t* fr, const int16_t* fi,
                           int16_t AvgPitchGain_Q12, enum ISACBand band,


### PR DESCRIPTION
First commit is a changeset from mozilla (released with 48) that fixes casts that give errors with gcc 5 and above. Allows build completion using gcc 6.4.0(though currently non-functional on the core platform); https://bugzilla.mozilla.org/show_bug.cgi?id=1257208

Second commit adds preprocessor macros in various functions to prevent tree vectorization from triggering a compiler bug with gcc-4.8.5. Adjusts depending on the target config. ( for #461 )