### PR TITLE
Intel fixes

### DIFF
--- a/client.mk
+++ b/client.mk
@@ -57,7 +57,7 @@ endif
 
 # try to find autoconf 2.13 - discard errors from 'which'
 # MacOS X 10.4 sends "no autoconf*" errors to stdout, discard those via grep
-AUTOCONF ?= $(shell which autoconf-2.13 autoconf2.13 autoconf213 2>/dev/null | grep -v '^no autoconf' | head -1)
+AUTOCONF ?= $(shell /usr/bin/which autoconf-2.13 autoconf2.13 autoconf213 2>/dev/null | grep -v '^no autoconf' | head -1)
 
 # See if the autoconf package was installed through fink
 ifeq (,$(strip $(AUTOCONF)))

--- a/config/external/nss/Makefile.in
+++ b/config/external/nss/Makefile.in
@@ -10,6 +10,17 @@ CXX_WRAPPER =
 
 default::
 
+ifeq (86,$(findstring 86,$(OS_TEST)))
+# TenFourFox Intel fix
+# TO DO - pass the compiler in as an environment variable
+CC=clang-mp-3.4
+CC              += -arch i386
+CC              += -O3
+CCC=clang++-mp-3.4
+CCC += -arch i386
+CCC += -O3
+endif
+
 include $(topsrcdir)/config/makefiles/functions.mk
 
 NSS_LIBS = \

--- a/gfx/ycbcr/yuv_row_posix.cpp
+++ b/gfx/ycbcr/yuv_row_posix.cpp
@@ -272,8 +272,7 @@ void FastConvertYUVToRGB32Row_SSE(const uint8* y_buf,
                                   int width);
   asm(
   ".text\n"
-  ".global FastConvertYUVToRGB32Row_SSE\n"
-  ".type FastConvertYUVToRGB32Row_SSE, @function\n"
+  ".globl FastConvertYUVToRGB32Row_SSE\n"
 "FastConvertYUVToRGB32Row_SSE:\n"
   "pusha\n"
   "mov    0x24(%esp),%edx\n"
@@ -350,8 +349,7 @@ void ScaleYUVToRGB32Row_SSE(const uint8* y_buf,
                             int source_dx);
   asm(
   ".text\n"
-  ".global ScaleYUVToRGB32Row_SSE\n"
-  ".type ScaleYUVToRGB32Row_SSE, @function\n"
+  ".globl ScaleYUVToRGB32Row_SSE\n"
 "ScaleYUVToRGB32Row_SSE:\n"
   "pusha\n"
   "mov    0x24(%esp),%edx\n"
@@ -444,8 +442,7 @@ void LinearScaleYUVToRGB32Row_SSE(const uint8* y_buf,
                                   int source_dx);
   asm(
   ".text\n"
-  ".global LinearScaleYUVToRGB32Row_SSE\n"
-  ".type LinearScaleYUVToRGB32Row_SSE, @function\n"
+  ".globl LinearScaleYUVToRGB32Row_SSE\n"
 "LinearScaleYUVToRGB32Row_SSE:\n"
   "pusha\n"
   "mov    0x24(%esp),%edx\n"

--- a/intel-Yonah.mozcfg
+++ b/intel-Yonah.mozcfg
@@ -1,6 +1,12 @@
 . $topsrcdir/browser/config/mozconfig
-export CC="/opt/local/bin/gcc-mp-4.8 -flax-vector-conversions -O3 -m32 -march=pentium-m -read_only_relocs suppress -mdynamic-no-pic"
-export CXX="/opt/local/bin/g++-mp-4.8 -flax-vector-conversions -fpermissive -O3 -m32 -march=pentium-m -read_only_relocs suppress -mdynamic-no-pic"
+
+# we need to use -Wa,-Q to force the behaviour of the traditional assembler on MacPorts
+# as that is the only one that can accept all the output from gcc-4.8 without errors
+# recent changes in MacPorts will force clang as assembler if certain clangs are found otherwise
+export CC="/opt/local/bin/gcc-mp-4.8 -Wa,-Q -flax-vector-conversions -O3 -m32 -march=pentium-m -read_only_relocs suppress"
+export CXX="/opt/local/bin/g++-mp-4.8 -Wa,-Q -flax-vector-conversions -fpermissive -O3 -m32 -march=pentium-m -read_only_relocs suppress"
+
+
 mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/obj-ff-dbg
 mk_add_options MOZ_MAKE_FLAGS="-s -j2"
 mk_add_options AUTOCONF=autoconf213

--- a/media/libvpx/Makefile.in
+++ b/media/libvpx/Makefile.in
@@ -9,6 +9,15 @@ VPX_AS=gcc
 VPX_ASM_SUFFIX=s
 endif
 
+ifdef VPX_X86_ASM
+# TO DO - pass these in as an environment variable
+CC=clang-mp-3.4
+CC += -arch i386
+CC += -O3
+VPX_AS=yasm
+VPX_ASM_SUFFIX=asm
+endif
+
 # Set up the libvpx assembler config.
 
 AS=$(VPX_AS)

--- a/media/libvpx/moz.build
+++ b/media/libvpx/moz.build
@@ -102,6 +102,7 @@ if CONFIG['CLANG_CL'] or not CONFIG['_MSC_VER']:
 if CONFIG['GNU_CC']:
     CFLAGS += ['-Wno-sign-compare']
 
+
 ASFLAGS += CONFIG['VPX_ASFLAGS']
 ASFLAGS += [
     '-I.',
@@ -109,7 +110,10 @@ ASFLAGS += [
     '-I%s/media/libvpx/vpx_ports/' % TOPSRCDIR,
 ]
 # moved from Makefile.in for TenFourFox
-ASFLAGS += ['-force_cpusubtype_ALL']
+
+# this only works on gcc-as (ie PPC)
+if not '86' in CONFIG['OS_TEST']:
+    ASFLAGS += ['-force_cpusubtype_ALL']
 
 if CONFIG['OS_TARGET'] == 'Android':
     # For LIBVPX_RAND


### PR DESCRIPTION
There is one more fix used, not in this PR, as gcc on > 10.4 does not put log2 into the standard namespace until gcc7 (long story ...).

Other than that, this is what I use to build TenFourFox on Intel systems 10.4 to 10.7. Could probably go up to 10.9, haven't tried. There are registration artifacts in the interface that creep in after a certain system OS version -- not sure where the cutoff is.

I have not been able to enable ION yet, but frankly haven't tried in a while. I was planning on giving that another go soon, probably asking @riccardo for a look too as he apparently has worked with it.

The toolchain on Tiger Intel takes some work. I use my TigerPorts overlay on top of current macports to get clang-3.4 etc going (also libc++, clang-3.7, clang-3.8, clang-5.0, and clang-7.0 all work on Tiger with that repo). cctools on Tiger Intel is current, but ld64 is stuck at ld64-97 due to the start code in the 10.4 SDK in crt0.o (otherwise building ld64-127 on Tiger is actually pretty simple)..