### PR TITLE
OlgaTPark/tenfourfox#14 — Add a Keyboard Shortcut to Reader Mode

### DIFF
--- a/browser/base/content/browser-menubar.inc
+++ b/browser/base/content/browser-menubar.inc
@@ -323,6 +323,7 @@
 #endif
                 <menuitem id="menu_readerModeItem"
                           observes="View:ReaderView"
+                          key="key_toggleReaderMode"
                           hidden="true"/>
                 <menuitem id="menu_showAllTabs"
                           hidden="true"

--- a/browser/base/content/browser-sets.inc
+++ b/browser/base/content/browser-sets.inc
@@ -366,6 +366,7 @@
     <key id="key_fullScreen_old" key="&fullScreenCmd.macCommandKey;" command="View:FullScreen" modifiers="accel,shift"/>
     <key keycode="VK_F11" command="View:FullScreen"/>
 #endif
+    <key id="key_toggleReaderMode" key="&toggleReaderMode.key;" command="View:ReaderView" modifiers="accel,alt" disabled="true"/>
     <key key="&reloadCmd.commandkey;" command="Browser:Reload" modifiers="accel" id="key_reload"/>
     <key key="&reloadCmd.commandkey;" command="Browser:ReloadSkipCache" modifiers="accel,shift"/>
     <key id="key_viewSource" key="&pageSourceCmd.commandkey;" command="View:PageSource" modifiers="accel"/>

--- a/browser/base/content/browser.js
+++ b/browser/base/content/browser.js
@@ -5407,6 +5407,7 @@ const nodeToTooltipMap = {
   "tabs-newtab-button": "newTabButton.tooltip",
   "fullscreen-button": "fullscreenButton.tooltip",
   "downloads-button": "downloads.tooltip",
+  "reader-mode-button": "reader-mode-button.tooltip",
 };
 const nodeToShortcutMap = {
   "bookmarks-menu-button": "manBookmarkKb",
@@ -5414,7 +5415,8 @@ const nodeToShortcutMap = {
   "new-tab-button": "key_newNavigatorTab",
   "tabs-newtab-button": "key_newNavigatorTab",
   "fullscreen-button": "key_fullScreen",
-  "downloads-button": "key_openDownloads"
+  "downloads-button": "key_openDownloads",
+  "reader-mode-button": "key_toggleReaderMode",
 };
 
 //if (AppConstants.platform == "macosx") {

--- a/browser/base/content/browser.xul
+++ b/browser/base/content/browser.xul
@@ -733,6 +733,7 @@
                        onclick="gPopupBlockerObserver.onReportButtonClick(event);"/>
                 <image id="reader-mode-button"
                        class="urlbar-icon"
+                       tooltip="dynamic-shortcut-tooltip"
                        hidden="true"
                        onclick="ReaderParent.buttonClick(event);"/>
               </hbox>

--- a/browser/locales/en-US/chrome/browser/browser.dtd
+++ b/browser/locales/en-US/chrome/browser/browser.dtd
@@ -105,6 +105,7 @@ These should match what Safari and other Apple applications use on OS X Lion. --
 <!ENTITY fullScreenCmd.macCommandKey "f">
 <!ENTITY showAllTabsCmd.label "Show All Tabs">
 <!ENTITY showAllTabsCmd.accesskey "A">
+<!ENTITY toggleReaderMode.key "R">
 
 <!ENTITY fxaSignIn.label "Sign in to &syncBrand.shortName.label;">
 <!ENTITY fxaSignedIn.tooltip "Open &syncBrand.shortName.label; preferences">

--- a/browser/locales/en-US/chrome/browser/browser.properties
+++ b/browser/locales/en-US/chrome/browser/browser.properties
@@ -291,6 +291,10 @@ tabHistory.goForward=Go forward to this page
 # URL Bar
 pasteAndGo.label=Paste & Go
 
+# LOCALIZATION NOTE (reader-mode-button.tooltip):
+# %S is the keyboard shortcut for entering/exiting reader view
+reader-mode-button.tooltip=Toggle reader view (%S)
+
 # Block autorefresh
 refreshBlocked.goButton=Allow
 refreshBlocked.goButton.accesskey=A

--- a/browser/modules/ReaderParent.jsm
+++ b/browser/modules/ReaderParent.jsm
@@ -139,22 +139,23 @@ var ReaderParent = {
 
     let button = win.document.getElementById("reader-mode-button");
     let command = win.document.getElementById("View:ReaderView");
+    let key = win.document.getElementById("key_toggleReaderMode");
     if (browser.currentURI.spec.startsWith("about:reader")) {
       button.setAttribute("readeractive", true);
       button.hidden = false;
       let closeText = gStringBundle.GetStringFromName("readerView.close");
-      button.setAttribute("tooltiptext", closeText);
       command.setAttribute("label", closeText);
       command.setAttribute("hidden", false);
       command.setAttribute("accesskey", gStringBundle.GetStringFromName("readerView.close.accesskey"));
+      key.setAttribute("disabled", false);
     } else {
       button.removeAttribute("readeractive");
       button.hidden = !browser.isArticle;
       let enterText = gStringBundle.GetStringFromName("readerView.enter");
-      button.setAttribute("tooltiptext", enterText);
       command.setAttribute("label", enterText);
       command.setAttribute("hidden", !browser.isArticle);
       command.setAttribute("accesskey", gStringBundle.GetStringFromName("readerView.enter.accesskey"));
+      key.setAttribute("disabled", !browser.isArticle);
     }
 
     let currentUriHost = browser.currentURI && browser.currentURI.asciiHost;


### PR DESCRIPTION
Here are the changes discussed in OlgaTPark/tenfourfox#14 needed to add a keyboard shortcut to Reader Mode (the patches are based on PowerPC TenFourFox FPR6 because I tested them in <i>Olga</i>Fox FPR6).   
This commit doesn't include [M1438308](https://bugzilla.mozilla.org/show_bug.cgi?id=1438308) which changes the shortcut on Windows to `F9`.   
I also didn't included [M1480415](https://bugzilla.mozilla.org/show_bug.cgi?id=1480415) which concerns a Windows screen reader that cannot "see" the reader button in the toolbar (but I doesn't expect a better situation on Mac OS X).   

If you want, I can also add the changes for the `pdfjs.display.use_document_fonts=true` setting to this pull request.   

Concerning localizations, two files are affected:   

https://github.com/OlgaTPark/tenfourfox/commit/8c65cb0c773492a235d8b253301155e23b51130d#diff-38fb3065c40acfe9cd97e7cd67908052R102-R113   
`/browser/locales/en-US/chrome/browser/browser.dtd`
```
 <!ENTITY enterFullScreenCmd.accesskey "F">
 <!ENTITY exitFullScreenCmd.label "Exit Full Screen">
 <!ENTITY exitFullScreenCmd.accesskey "F">
 <!ENTITY fullScreenCmd.label "Full Screen">
 <!ENTITY fullScreenCmd.accesskey "F">
 <!ENTITY fullScreenCmd.macCommandKey "f">
 <!ENTITY showAllTabsCmd.label "Show All Tabs">
 <!ENTITY showAllTabsCmd.accesskey "A">
+<!ENTITY toggleReaderMode.key "R">
 
 <!ENTITY fxaSignIn.label "Sign in to &syncBrand.shortName.label;">
 <!ENTITY fxaSignedIn.tooltip "Open &syncBrand.shortName.label; preferences">
 <!ENTITY fxaSignInError.label "Reconnect to &syncBrand.shortName.label;">
 <!ENTITY fxaUnverified.label "Verify Your Account">
```
(which ends up in `{TenFourFox.app/Content/Resources}/browser/chrome/en-US/locale/browser/browser.dtd`).    
Here, the change is the same for every locale (checked in Mozilla XPI<sub>s</sub>).   

And:   
https://github.com/OlgaTPark/tenfourfox/commit/8c65cb0c773492a235d8b253301155e23b51130d#diff-0b08792398c408a93dd2a72b4b61cab5L286-L295   
`/browser/locales/en-US/chrome/browser/browser.properties`
```
 # Unified Back-/Forward Popup
 tabHistory.current=Stay on this page
 tabHistory.goBack=Go back to this page
 tabHistory.goForward=Go forward to this page
 
 # URL Bar
 pasteAndGo.label=Paste & Go
+# LOCALIZATION NOTE (reader-mode-button.tooltip):
+# %S is the keyboard shortcut for entering/exiting reader view
+reader-mode-button.tooltip=Toggle reader view (%S)
  
 # Block autorefresh
 refreshBlocked.goButton=Allow
```
(which ends up in `{TenFourFox.app/Content/Resources}/browser/chrome/en-US/locale/browser/browser.properties`).    

I extracted the translated strings for every locale supported by TenFourFox from <http://ftp.mozilla.org/pub/firefox/releases/60.0/mac/xpi/>:   
    
|Locale|                          Translated string                          |
|------|---------------------------------------------------------------------|
|de    |`reader-mode-button.tooltip=Leseansicht umschalten (%S)`             |
|en-US |`reader-mode-button.tooltip=Toggle reader view (%S)`                 |
|es-ES |`reader-mode-button.tooltip=Cambiar vista de lectura (%S)`           |
|fi    |`reader-mode-button.tooltip=Näytä/piilota lukunäkymä (%S)`           |
|fr    |`reader-mode-button.tooltip=Activer/Désactiver le mode lecture (%S)` |
|it    |`reader-mode-button.tooltip = Attiva/disattiva Modalità lettura (%S)`|
|ko    |`reader-mode-button.tooltip=읽기 모드 토글(%S)`                        |
|pl    |`reader-mode-button.tooltip=Przełącz poprawianie czytelności (%S)`   |
|ru    |`reader-mode-button.tooltip=Включить/отключить Вид для чтения (%S)`  |
|sv-SE |`reader-mode-button.tooltip=Växla läsvy (%S)`                        |
|tr    |`reader-mode-button.tooltip=Okuyucu görünümünü aç/kapat (%S)`        |
|zh-CN |`reader-mode-button.tooltip=切换阅读器视图 (%S)`                       |
   
And for my forgiveness, I can already translate the strings from <https://github.com/classilla/tenfourfox/issues/328#issuecomment-703730518> in French:
 - "Domain" => "Domaine"   
   - I `grep`ed it in the localizations to see if it's already somewhere else and I've found:
     - `TenFourFox.app/Contents/Resources/chrome/fr/locale/fr/cookie/cookieAcceptDialog.properties`: `domainColon=Domaine :`   
     - `TenFourFox.app/Contents/Resources/browser/chrome/fr/locale/fr/devtools/client/netmonitor.dtd`: `<!ENTITY netmonitorUI.toolbar.domain      "Domaine">`   
	 - `TenFourFox.app/Contents/Resources/browser/chrome/fr/locale/browser/preferences/cookies.dtd`: `<!ENTITY     props.domain.label             "Hôte :">` (This variant has a « Hostname » meaning)   
 - "Configure Site Preferences" => "Configurer les préférences du site"   
 - "Always Open in Reader View" => "Toujours ouvrir en mode lecture"   