### PR TITLE
OlgaTPark/tenfourfox#14 — Allow saving passwords in private windows with a dismissed-by-default doorhanger

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -1622,6 +1622,8 @@ pref("browser.pocket.oAuthConsumerKey", "40249-e88c401e1b1f2242d9e441c4");
 pref("browser.pocket.useLocaleList", true);
 pref("browser.pocket.enabledLocales", "cs de en-GB en-US en-ZA es-ES es-MX fr hu it ja ja-JP-mac ko nl pl pt-BR pt-PT ru zh-CN zh-TW");
 
+pref("signon.privateBrowsingCapture.enabled", true);
+
 pref("view_source.tab", true);
 
 pref("dom.webnotifications.serviceworker.enabled", true);

--- a/browser/components/preferences/in-content/security.js
+++ b/browser/components/preferences/in-content/security.js
@@ -99,23 +99,15 @@ var gSecurityPane = {
 
   /**
    * Enables/disables the Exceptions button used to configure sites where
-   * passwords are never saved. When browser is set to start in Private
-   * Browsing mode, the "Remember passwords" UI is useless, so we disable it.
+   * passwords are never saved.
    */
   readSavePasswords: function ()
   {
-    var pref = document.getElementById("signon.rememberSignons");
-    var excepts = document.getElementById("passwordExceptions");
+    var prefValue = document.getElementById("signon.rememberSignons").value;
+    document.getElementById("passwordExceptions").disabled = !prefValue;
 
-    if (PrivateBrowsingUtils.permanentPrivateBrowsing) {
-      document.getElementById("savePasswords").disabled = true;
-      excepts.disabled = true;
-      return false;
-    } else {
-      excepts.disabled = !pref.value;
-      // don't override pref value in UI
-      return undefined;
-    }
+    // don't override pref value in UI
+    return undefined;
   },
 
   /**

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -4088,6 +4088,7 @@ pref("signon.rememberSignons.visibilityToggle", false);
 #endif
 pref("signon.autofillForms",                true);
 pref("signon.autologin.proxy",              false);
+pref("signon.privateBrowsingCapture.enabled", false);
 pref("signon.storeWhenAutocompleteOff",     true);
 pref("signon.ui.experimental",              false);
 pref("signon.debug",                        false);

--- a/toolkit/components/passwordmgr/LoginHelper.jsm
+++ b/toolkit/components/passwordmgr/LoginHelper.jsm
@@ -37,6 +37,8 @@ this.LoginHelper = {
    * Warning: this only updates if a logger was created.
    */
   debug: Services.prefs.getBoolPref("signon.debug"),
+  privateBrowsingCaptureEnabled:
+    Services.prefs.getBoolPref("signon.privateBrowsingCapture.enabled"),
 
   createLogger(aLogPrefix) {
     let getMaxLogLevel = () => {
@@ -54,6 +56,8 @@ this.LoginHelper = {
     // Watch for pref changes and update this.debug and the maxLogLevel for created loggers
     Services.prefs.addObserver("signon.", () => {
       this.debug = Services.prefs.getBoolPref("signon.debug");
+      this.privateBrowsingCaptureEnabled =
+        Services.prefs.getBoolPref("signon.privateBrowsingCapture.enabled");
       logger.maxLogLevel = getMaxLogLevel();
     }, false);
 

--- a/toolkit/components/passwordmgr/LoginManagerContent.jsm
+++ b/toolkit/components/passwordmgr/LoginManagerContent.jsm
@@ -752,7 +752,8 @@ var LoginManagerContent = {
     var doc = form.ownerDocument;
     var win = doc.defaultView;
 
-    if (PrivateBrowsingUtils.isContentWindowPrivate(win)) {
+    if (PrivateBrowsingUtils.isContentWindowPrivate(win) &&
+        !LoginHelper.privateBrowsingCaptureEnabled) {
       // We won't do anything in private browsing mode anyway,
       // so there's no need to perform further checks.
       log("(form submission ignored in private browsing mode)");

--- a/toolkit/components/passwordmgr/LoginManagerParent.jsm
+++ b/toolkit/components/passwordmgr/LoginManagerParent.jsm
@@ -21,6 +21,8 @@ XPCOMUtils.defineLazyModuleGetter(this, "LoginDoorhangers",
                                   "resource://gre/modules/LoginDoorhangers.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "LoginHelper",
                                   "resource://gre/modules/LoginHelper.jsm");
+XPCOMUtils.defineLazyModuleGetter(this, "PrivateBrowsingUtils",
+                                  "resource://gre/modules/PrivateBrowsingUtils.jsm");
 
 XPCOMUtils.defineLazyGetter(this, "log", () => {
   let logger = LoginHelper.createLogger("LoginManagerParent");
@@ -435,6 +437,10 @@ var LoginManagerParent = {
     }
 
     function recordLoginUse(login) {
+      if (!target || PrivateBrowsingUtils.isBrowserPrivate(target)) {
+        // don't record non-interactive use in private browsing
+        return;
+      }
       // Update the lastUsed timestamp and increment the use count.
       let propBag = Cc["@mozilla.org/hash-property-bag;1"].
                     createInstance(Ci.nsIWritablePropertyBag);


### PR DESCRIPTION
Hello (if you ever remember that I've existed at some point in time), 

Here are the changes allowing to save passwords in private browsing and the [M1660998](http://bugzil.la/1660998) fix for the `Remember logins for sites` in `about:preferences#security`.  Useless details are uselessly present in the useless commit comment (did I noted it's _useless_?).  Both were locally tested in _OlgaFox_ FPR7 and FPR8.  (Somewhat later than what I've announced to let you rest during end-of-year, as requested, plus other delays on my side…)

Of course, implementing this can wait the next beta cycle of TenFourFox and I personally prefer to see this change in a _beta_ build prior a _release_ one, just to be really sure that everything is OK.

Anyway, happy browsing (since « Happy new year » would be too late) and sorry for the [silence](https://monster.fandom.com/wiki/Silence)!